### PR TITLE
[CRM-5] permission and admin access

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -10,37 +10,54 @@
  * @author Barry vd. Heuvel <barryvdh@gmail.com>
  */
 
-
 namespace App\Models{
-/**
- * 
- *
- * @property int $id
- * @property string $name
- * @property string $email
- * @property \Illuminate\Support\Carbon|null $email_verified_at
- * @property mixed $password
- * @property string|null $remember_token
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
- * @property-read int|null $notifications_count
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Laravel\Sanctum\PersonalAccessToken> $tokens
- * @property-read int|null $tokens_count
- * @method static \Database\Factories\UserFactory factory($count = null, $state = [])
- * @method static \Illuminate\Database\Eloquent\Builder|User newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|User newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|User query()
- * @method static \Illuminate\Database\Eloquent\Builder|User whereCreatedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereEmail($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereEmailVerifiedAt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereId($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereName($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User wherePassword($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereRememberToken($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereUpdatedAt($value)
- * @mixin \Eloquent
- */
-	class User extends \Eloquent {}
+    /**
+     *
+     *
+     * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+     * @property-read int|null $users_count
+     * @method static \Illuminate\Database\Eloquent\Builder|Permission newModelQuery()
+     * @method static \Illuminate\Database\Eloquent\Builder|Permission newQuery()
+     * @method static \Illuminate\Database\Eloquent\Builder|Permission query()
+     */
+    class Permission extends \Eloquent
+    {
+    }
 }
 
+namespace App\Models{
+    /**
+     *
+     *
+     * @property int $id
+     * @property string $name
+     * @property string $email
+     * @property \Illuminate\Support\Carbon|null $email_verified_at
+     * @property mixed $password
+     * @property string|null $remember_token
+     * @property \Illuminate\Support\Carbon|null $created_at
+     * @property \Illuminate\Support\Carbon|null $updated_at
+     * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
+     * @property-read int|null $notifications_count
+     * @property-read \Illuminate\Database\Eloquent\Collection<int, \Laravel\Sanctum\PersonalAccessToken> $tokens
+     * @property-read int|null $tokens_count
+     * @method static \Database\Factories\UserFactory factory($count = null, $state = [])
+     * @method static \Illuminate\Database\Eloquent\Builder|User newModelQuery()
+     * @method static \Illuminate\Database\Eloquent\Builder|User newQuery()
+     * @method static \Illuminate\Database\Eloquent\Builder|User query()
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereCreatedAt($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereEmail($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereEmailVerifiedAt($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereId($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereName($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User wherePassword($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereRememberToken($value)
+     * @method static \Illuminate\Database\Eloquent\Builder|User whereUpdatedAt($value)
+     * @mixin \Eloquent
+     * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Permission> $permissions
+     * @property-read int|null $permissions_count
+     */
+    class User extends \Eloquent
+    {
+    }
+}

--- a/app/Enum/Can.php
+++ b/app/Enum/Can.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace App\Enum;
 
 enum Can: string
 {

--- a/app/Livewire/Admin/Dashboard.php
+++ b/app/Livewire/Admin/Dashboard.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Enum\Can;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class Dashboard extends Component
+{
+    public function mount(): void
+    {
+        $this->authorize(Can::BE_AN_ADMIN->value);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.admin.dashboard');
+    }
+}

--- a/app/Models/Can.php
+++ b/app/Models/Can.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Models;
+
+enum Can: string
+{
+    case BE_AN_ADMIN = 'be_an_admin';
+}

--- a/app/Models/HasPermissions.php
+++ b/app/Models/HasPermissions.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Cache;
+
+trait HasPermissions
+{
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+
+    public function givePermissionTo(string $key): void
+    {
+        $this->permissions()->firstOrCreate(compact('key'));
+
+        Cache::forget($this->getPermissionCacheKey());
+
+        Cache::rememberForever(
+            $this->getPermissionCacheKey(),
+            fn () => $this->permissions
+        );
+
+    }
+
+    public function hasPermissionTo(string $key): bool
+    {
+        /** @var Collection $permissions  */
+        $permissions = Cache::get($this->getPermissionCacheKey(), $this->permissions);
+
+        return $permissions
+            ->where('key', '=', $key)
+            ->isNotEmpty();
+    }
+
+    public function getPermissionCacheKey(): string
+    {
+        return "user::{$this->id}::permissions";
+    }
+
+}

--- a/app/Models/HasPermissions.php
+++ b/app/Models/HasPermissions.php
@@ -13,9 +13,14 @@ trait HasPermissions
         return $this->belongsToMany(Permission::class);
     }
 
-    public function givePermissionTo(string $key): void
+    public function givePermissionTo(Can|string $key): void
     {
-        $this->permissions()->firstOrCreate(compact('key'));
+
+        $pKey = $key instanceof Can
+            ? $key->value
+            : $key;
+
+        $this->permissions()->firstOrCreate(['key' => $pKey]);
 
         Cache::forget($this->getPermissionCacheKey());
 
@@ -26,13 +31,17 @@ trait HasPermissions
 
     }
 
-    public function hasPermissionTo(string $key): bool
+    public function hasPermissionTo(Can|string $key): bool
     {
+        $pKey = $key instanceof Can
+            ? $key->value
+            : $key;
+
         /** @var Collection $permissions  */
         $permissions = Cache::get($this->getPermissionCacheKey(), $this->permissions);
 
         return $permissions
-            ->where('key', '=', $key)
+            ->where('key', '=', $pKey)
             ->isNotEmpty();
     }
 

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    protected $fillable = [
+        'key',
+    ];
+
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\Models\HasPermissions;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Cache;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -69,10 +71,27 @@ class User extends Authenticatable
     {
         $this->permissions()->firstOrCreate(compact('key'));
 
+        Cache::forget($this->getPermissionCacheKey());
+
+        Cache::rememberForever(
+            $this->getPermissionCacheKey(),
+            fn () => $this->permissions
+        );
+
     }
 
     public function hasPermissionTo(string $key): bool
     {
-        return $this->permissions()->where(compact('key'))->exists();
+        /** @var Collection $permissions  */
+        $permissions = Cache::get($this->getPermissionCacheKey(), $this->permissions);
+
+        return $permissions
+            ->where('key', '=', $key)
+            ->isNotEmpty();
+    }
+
+    public function getPermissionCacheKey(): string
+    {
+        return "user::{$this->id}::permissions";
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,13 +2,9 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Facades\Cache;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -45,6 +41,7 @@ class User extends Authenticatable
     use HasApiTokens;
     use HasFactory;
     use Notifiable;
+    use HasPermissions;
 
     protected $fillable = [
         'name',
@@ -61,37 +58,4 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
     ];
-
-    public function permissions(): BelongsToMany
-    {
-        return $this->belongsToMany(Permission::class);
-    }
-
-    public function givePermissionTo(string $key): void
-    {
-        $this->permissions()->firstOrCreate(compact('key'));
-
-        Cache::forget($this->getPermissionCacheKey());
-
-        Cache::rememberForever(
-            $this->getPermissionCacheKey(),
-            fn () => $this->permissions
-        );
-
-    }
-
-    public function hasPermissionTo(string $key): bool
-    {
-        /** @var Collection $permissions  */
-        $permissions = Cache::get($this->getPermissionCacheKey(), $this->permissions);
-
-        return $permissions
-            ->where('key', '=', $key)
-            ->isNotEmpty();
-    }
-
-    public function getPermissionCacheKey(): string
-    {
-        return "user::{$this->id}::permissions";
-    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,13 +4,12 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
- *
- *
  * @property int $id
  * @property string $name
  * @property string $email
@@ -23,6 +22,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read int|null $notifications_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Laravel\Sanctum\PersonalAccessToken> $tokens
  * @property-read int|null $tokens_count
+ *
  * @method static \Database\Factories\UserFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|User newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|User newQuery()
@@ -35,6 +35,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @method static \Illuminate\Database\Eloquent\Builder|User wherePassword($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereRememberToken($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereUpdatedAt($value)
+ *
  * @mixin \Eloquent
  */
 class User extends Authenticatable
@@ -58,4 +59,20 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password'          => 'hashed',
     ];
+
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class);
+    }
+
+    public function givePermissionTo(string $key): void
+    {
+        $this->permissions()->firstOrCreate(compact('key'));
+
+    }
+
+    public function hasPermissionTo(string $key): bool
+    {
+        return $this->permissions()->where(compact('key'))->exists();
+    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,8 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
-use App\Models\{Can, User};
+use App\Enum\Can;
+use App\Models\{User};
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -18,7 +18,7 @@ class AuthServiceProvider extends ServiceProvider
     {
         foreach (Can::cases() as $can) {
             Gate::define(
-                str($can->value)->snake('-')->toString(),
+                $can->value,
                 fn (User $user) => $user->hasPermissionTo($can)
             );
         }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\User;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -13,6 +15,6 @@ class AuthServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        //
+        Gate::define('be-an-admin', fn (User $user) => $user->hasPermissionTo('be an admin'));
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
-use App\Models\User;
+use App\Models\{Can, User};
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 
@@ -15,6 +15,11 @@ class AuthServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
-        Gate::define('be-an-admin', fn (User $user) => $user->hasPermissionTo('be an admin'));
+        foreach (Can::cases() as $can) {
+            Gate::define(
+                str($can->value)->snake('-')->toString(),
+                fn (User $user) => $user->hasPermissionTo($can)
+            );
+        }
     }
 }

--- a/app/Traits/Models/HasPermissions.php
+++ b/app/Traits/Models/HasPermissions.php
@@ -1,7 +1,9 @@
 <?php
 
-namespace App\Models;
+namespace App\Traits\Models;
 
+use App\Enum\Can;
+use App\Models\Permission;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Facades\Cache;

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.0",
         "fakerphp/faker": "^1.9.1",
+        "laradumps/laradumps-core": "^3.0",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae9dfcc7ffa72aa3ac0d6f9c3fde9cd0",
+    "content-hash": "15a96aae8728bacdf82f183f69059295",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -6963,6 +6963,75 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.6"
             },
             "time": "2024-03-08T09:58:59+00:00"
+        },
+        {
+            "name": "laradumps/laradumps-core",
+            "version": "v3.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laradumps/laradumps-core.git",
+                "reference": "eb0e15805ac4061a524c43ed7c1e7796ef3326d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laradumps/laradumps-core/zipball/eb0e15805ac4061a524c43ed7c1e7796ef3326d8",
+                "reference": "eb0e15805ac4061a524c43ed7c1e7796ef3326d8",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "nunomaduro/termwind": "^1.15|^2.0",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.7.5",
+                "spatie/backtrace": "^1.5",
+                "symfony/console": "^5.4|^6.4|^7.0",
+                "symfony/finder": "^5.4|^6.4|^7.0",
+                "symfony/process": "^5.4|^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.4|^7.0",
+                "symfony/yaml": "^5.4|^6.4|^7.0"
+            },
+            "require-dev": {
+                "illuminate/support": "^10.46",
+                "laravel/pint": "^1.13.7",
+                "pestphp/pest": "^2.0|^3.0",
+                "phpstan/phpstan": "^1.10.50"
+            },
+            "bin": [
+                "bin/laradumps"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LaraDumps\\LaraDumpsCore\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luan Freitas",
+                    "email": "luanfreitas10@protonmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "LaraDumps is a friendly app designed to boost your Laravel / PHP coding and debugging experience.",
+            "homepage": "https://github.com/laradumps/laradumps-core",
+            "support": {
+                "issues": "https://github.com/laradumps/laradumps-core/issues",
+                "source": "https://github.com/laradumps/laradumps-core/tree/v3.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/luanfreitasdev",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-05-16T14:48:30+00:00"
         },
         {
             "name": "laravel/pint",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -40,5 +41,12 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    public function withPermission(string $key): static
+    {
+        return $this->afterCreating(
+            fn (User $user) => $user->givePermissionTo('be an admin')
+        );
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,7 +2,8 @@
 
 namespace Database\Factories;
 
-use App\Models\{Can, User};
+use App\Enum\Can;
+use App\Models\{User};
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,7 +2,7 @@
 
 namespace Database\Factories;
 
-use App\Models\User;
+use App\Models\{Can, User};
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -43,10 +43,10 @@ class UserFactory extends Factory
         ]);
     }
 
-    public function withPermission(string $key): static
+    public function withPermission(Can $key): static
     {
         return $this->afterCreating(
-            fn (User $user) => $user->givePermissionTo('be an admin')
+            fn (User $user) => $user->givePermissionTo($key)
         );
     }
 }

--- a/database/migrations/2025_05_26_170231_create_permissions_table.php
+++ b/database/migrations/2025_05_26_170231_create_permissions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('key');
+            $table->timestamps();
+        });
+
+        //orderm alfabetica e no singular nome da table permission_user
+        Schema::create('permission_user', function (Blueprint $table) {
+            $table->foreignId('user_id');
+            $table->foreignId('permission_id');
+            // index serve para facilitar a busca e melhorar a performance
+            $table->index(['user_id', 'permission_id']);
+            $table->unique(['user_id', 'permission_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+        Schema::dropIfExists('permission_user');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,7 +3,6 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-use App\Models\User;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -15,11 +14,10 @@ class DatabaseSeeder extends Seeder
     {
         // \App\Models\User::factory(10)->create();
 
-        $this->call(PermissionSeeder::class);
-
-        User::factory()->create([
-            'name'  => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            PermissionSeeder::class,
+            UserSeeder::class,
         ]);
+
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\User;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -14,7 +15,9 @@ class DatabaseSeeder extends Seeder
     {
         // \App\Models\User::factory(10)->create();
 
-        \App\Models\User::factory()->create([
+        $this->call(PermissionSeeder::class);
+
+        User::factory()->create([
             'name'  => 'Test User',
             'email' => 'test@example.com',
         ]);

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -2,7 +2,8 @@
 
 namespace Database\Seeders;
 
-use App\Models\{Can, Permission};
+use App\Enum\Can;
+use App\Models\{Permission};
 use Illuminate\Database\Seeder;
 
 class PermissionSeeder extends Seeder

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Permission;
+use Illuminate\Database\Seeder;
+
+class PermissionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Permission::create(['key' => 'be an admin']);
+    }
+}

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -2,13 +2,13 @@
 
 namespace Database\Seeders;
 
-use App\Models\Permission;
+use App\Models\{Can, Permission};
 use Illuminate\Database\Seeder;
 
 class PermissionSeeder extends Seeder
 {
     public function run(): void
     {
-        Permission::create(['key' => 'be an admin']);
+        Permission::create(['key' => Can::BE_AN_ADMIN]);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
+use App\Models\{Can, User};
 use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder
@@ -10,7 +10,7 @@ class UserSeeder extends Seeder
     public function run(): void
     {
         User::factory()
-            ->withPermission('be an admin')
+            ->withPermission(Can::BE_AN_ADMIN)
             ->create([
                 'name'  => 'Admin do CRM',
                 'email' => 'admin@crm.com',

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory()
+            ->withPermission('be an admin')
+            ->create([
+                'name'  => 'Admin do CRM',
+                'email' => 'admin@crm.com',
+            ]);
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -2,7 +2,8 @@
 
 namespace Database\Seeders;
 
-use App\Models\{Can, User};
+use App\Enum\Can;
+use App\Models\{User};
 use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder

--- a/laradumps.yaml
+++ b/laradumps.yaml
@@ -1,0 +1,20 @@
+app:
+    dispatcher: curl
+    primary_host: 127.0.0.1
+    secondary_host: host.docker.internal
+    port: 9191
+    workdir: /var/www/html/
+    project_path: 'C:/Users/coelho/Documents/projects/pa/crm-livewire-v3\'
+    wsl_config: wsl+Ubuntu/
+config:
+    sleep: 0
+    macos_auto_launch: false
+observers:
+    auto_invoke_app: false
+    enabled_in_testing: false
+xdebug:
+    client_host: 0.0.0.0
+    client_port: 9003
+code_snippet:
+    above: 9
+    below: 3

--- a/laradumps.yaml
+++ b/laradumps.yaml
@@ -1,20 +1,20 @@
 app:
-    dispatcher: curl
-    primary_host: 127.0.0.1
-    secondary_host: host.docker.internal
-    port: 9191
-    workdir: /var/www/html/
-    project_path: 'C:/Users/coelho/Documents/projects/pa/crm-livewire-v3\'
-    wsl_config: wsl+Ubuntu/
+  dispatcher: curl
+  primary_host: 127.0.0.1
+  secondary_host: host.docker.internal
+  port: 9191
+  workdir: /var/www/html/
+  project_path: C:/Users/coelho/Documents/projects/pa/crm-livewire-v3\
+  wsl_config: wsl+Ubuntu/
 config:
-    sleep: 0
-    macos_auto_launch: false
+  sleep: 0
+  macos_auto_launch: false
 observers:
-    auto_invoke_app: false
-    enabled_in_testing: false
+  auto_invoke_app: true
+  enabled_in_testing: true
 xdebug:
-    client_host: 0.0.0.0
-    client_port: 9003
+  client_host: 0.0.0.0
+  client_port: 9003
 code_snippet:
-    above: 9
-    below: 3
+  above: 9
+  below: 3

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -47,10 +47,17 @@
                 @endif
 
                 <x-menu-item title="Hello" icon="o-sparkles" link="/" />
+
                 <x-menu-sub title="Settings" icon="o-cog-6-tooth">
                     <x-menu-item title="Wifi" icon="o-wifi" link="####" />
                     <x-menu-item title="Archives" icon="o-archive-box" link="####" />
                 </x-menu-sub>
+
+                @can(\App\Enum\Can::BE_AN_ADMIN->value)
+                <x-menu-sub title="Admin" icon="o-lock-closed">
+                    <x-menu-item title="Dashboard" icon="o-chart-bar-square" :link="route('admin.dashboard')" />
+                </x-menu-sub>
+                @endcan
             </x-menu>
         </x-slot:sidebar>
 

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -1,0 +1,3 @@
+<div>
+    hi I am dashboard
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,14 +4,22 @@ use App\Livewire\Auth\{Login, Password, Register};
 use App\Livewire\Welcome;
 use Illuminate\Support\Facades\Route;
 
-//Route::get('/', Welcome::class)->name('dashboard');
-
+//region Login Flow
 Route::get('/login', Login::class)->name('login');
 Route::get('/register', Register::class)->name('register');
 Route::get('/logout', fn () => auth()->logout())->name('logout');
 Route::get('/password/recovery', Password\Recovery::class)->name('password.recovery');
 Route::get('/password/reset', Password\Reset::class)->name('password.reset');
+//endregion
 
+//region Authenticated
 Route::middleware('auth')->group(function () {
     Route::get('/', Welcome::class)->name('dashboard');
+
+    //region Admin Routes
+    Route::prefix('/admin')->middleware('can:be-an-admin')->group(function () {
+        Route::get('/dashboard', fn () => 'admin.dashboard')->name('admin.dashboard');
+    });
+    //endregion
 });
+//endregion

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,7 @@
 
 use App\Enum\Can;
 use App\Livewire\Auth\{Login, Password, Register};
-use App\Livewire\Welcome;
+use App\Livewire\{Admin, Welcome};
 use Illuminate\Support\Facades\Route;
 
 //region Login Flow
@@ -19,7 +19,7 @@ Route::middleware('auth')->group(function () {
 
     //region Admin Routes
     Route::prefix('/admin')->middleware('can:' . Can::BE_AN_ADMIN->value)->group(function () {
-        Route::get('/dashboard', fn () => 'admin.dashboard')->name('admin.dashboard');
+        Route::get('/dashboard', Admin\Dashboard::class)->name('admin.dashboard');
     });
     //endregion
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\Can;
 use App\Livewire\Auth\{Login, Password, Register};
 use App\Livewire\Welcome;
 use Illuminate\Support\Facades\Route;
@@ -17,7 +18,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/', Welcome::class)->name('dashboard');
 
     //region Admin Routes
-    Route::prefix('/admin')->middleware('can:be-an-admin')->group(function () {
+    Route::prefix('/admin')->middleware('can:' . Can::BE_AN_ADMIN->value)->group(function () {
         Route::get('/dashboard', fn () => 'admin.dashboard')->name('admin.dashboard');
     });
     //endregion

--- a/tests/Feature/Admin/DashboardTest.php
+++ b/tests/Feature/Admin/DashboardTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Livewire\Admin\Dashboard;
+use App\Models\User;
+
+use function Pest\Laravel\{actingAs, get};
+
+test('should block access to users without permission _be an admin_', function () {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    Livewire::test(Dashboard::class)
+        ->assertForbidden();
+
+    get(route('admin.dashboard'))
+        ->assertForbidden();
+});

--- a/tests/Feature/ArchTest.php
+++ b/tests/Feature/ArchTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('globals')
+    ->expect(['dd', 'dump', 'ray', 'ds'])
+    ->not->toBeUsed();

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Models\{Permission, User};
+
+use function Pest\Laravel\assertDatabaseHas;
+
+it('should be able to give an user a permission to do something', function () {
+
+    /** @var User $user */
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('be an admin');
+
+    expect($user)
+        ->hasPermissionTo('be an admin')
+        ->toBeTrue();
+
+    assertDatabaseHas('permissions', [
+        'key' => 'be an admin',
+    ]);
+
+    assertDatabaseHas('permission_user', [
+        'user_id'       => $user->id,
+        'permission_id' => Permission::where('key', '=', 'be an admin')->first()->id,
+    ]);
+
+});

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -3,7 +3,7 @@
 use App\Models\{Permission, User};
 use Database\Seeders\{PermissionSeeder, UserSeeder};
 
-use function Pest\Laravel\{assertDatabaseHas, seed};
+use function Pest\Laravel\{actingAs, assertDatabaseHas, seed};
 
 it('should be able to give an user a permission to do something', function () {
 
@@ -46,5 +46,13 @@ test('seed with an admin user', function () {
         'user_id'       => User::first()?->id,
         'permission_id' => Permission::where('key', '=', 'be an admin')->first()?->id,
     ]);
+});
+
+test('should block the access to an admin page if the user does not hava the permission to be an admin', function () {
+    $user = User::factory()->create();
+
+    actingAs($user)
+        ->get(route('admin.dashboard'))
+        ->assertForbidden();
 
 });

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -1,6 +1,7 @@
 <?php
 
-use App\Models\{Can, Permission, User};
+use App\Enum\Can;
+use App\Models\{Permission, User};
 use Database\Seeders\{PermissionSeeder, UserSeeder};
 
 use function Pest\Laravel\{actingAs, assertDatabaseHas, seed};

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -28,7 +28,7 @@ it('should be able to give an user a permission to do something', function () {
 
 });
 
-test('permission has to have a seeder', function () {
+test('permission must a seeder', function () {
     $this->seed(PermissionSeeder::class);
 
     assertDatabaseHas('permissions', [

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\{Permission, User};
+use Database\Seeders\PermissionSeeder;
 
 use function Pest\Laravel\assertDatabaseHas;
 
@@ -24,4 +25,12 @@ it('should be able to give an user a permission to do something', function () {
         'permission_id' => Permission::where('key', '=', 'be an admin')->first()->id,
     ]);
 
+});
+
+test('permission has to have a seeder', function () {
+    $this->seed(PermissionSeeder::class);
+
+    assertDatabaseHas('permissions', [
+        'key' => 'be an admin',
+    ]);
 });

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -56,3 +56,26 @@ test('should block the access to an admin page if the user does not hava the per
         ->assertForbidden();
 
 });
+
+test('lets make sure that we are using cache to store user permissions', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('be an admin');
+
+    $cacheKey = "user::{$user->id}::permissions";
+
+    expect(\Illuminate\Support\Facades\Cache::has($cacheKey))->toBeTrue('Checking if cache has the key')
+        ->and(\Illuminate\Support\Facades\Cache::get($cacheKey))->toBe($user->permissions, 'Checking if permissions are the same as the user');
+});
+
+test('lets make sure that we are using the cache the retrieve/check when the user has the given permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('be an admin');
+
+    // Verificar que eu nao teve nenhum hit no bd a partir desse ponto
+    DB::listen(fn ($query) => throw new Exception('We got a hit'));
+    $user->hasPermissionTo('be an admin');
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Models\{Permission, User};
-use Database\Seeders\PermissionSeeder;
+use Database\Seeders\{PermissionSeeder, UserSeeder};
 
-use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\{assertDatabaseHas, seed};
 
 it('should be able to give an user a permission to do something', function () {
 
@@ -33,4 +33,18 @@ test('permission has to have a seeder', function () {
     assertDatabaseHas('permissions', [
         'key' => 'be an admin',
     ]);
+});
+
+test('seed with an admin user', function () {
+    seed([PermissionSeeder::class, UserSeeder::class]);
+
+    assertDatabaseHas('permissions', [
+        'key' => 'be an admin',
+    ]);
+
+    assertDatabaseHas('permission_user', [
+        'user_id'       => User::first()?->id,
+        'permission_id' => Permission::where('key', '=', 'be an admin')->first()?->id,
+    ]);
+
 });

--- a/tests/Feature/PermisssionControlTest.php
+++ b/tests/Feature/PermisssionControlTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Models\{Permission, User};
+use App\Models\{Can, Permission, User};
 use Database\Seeders\{PermissionSeeder, UserSeeder};
 
 use function Pest\Laravel\{actingAs, assertDatabaseHas, seed};
@@ -10,19 +10,19 @@ it('should be able to give an user a permission to do something', function () {
     /** @var User $user */
     $user = User::factory()->create();
 
-    $user->givePermissionTo('be an admin');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     expect($user)
-        ->hasPermissionTo('be an admin')
+        ->hasPermissionTo(Can::BE_AN_ADMIN)
         ->toBeTrue();
 
     assertDatabaseHas('permissions', [
-        'key' => 'be an admin',
+        'key' => Can::BE_AN_ADMIN->value,
     ]);
 
     assertDatabaseHas('permission_user', [
         'user_id'       => $user->id,
-        'permission_id' => Permission::where('key', '=', 'be an admin')->first()->id,
+        'permission_id' => Permission::where('key', '=', Can::BE_AN_ADMIN->value)->first()->id,
     ]);
 
 });
@@ -31,7 +31,7 @@ test('permission has to have a seeder', function () {
     $this->seed(PermissionSeeder::class);
 
     assertDatabaseHas('permissions', [
-        'key' => 'be an admin',
+        'key' => Can::BE_AN_ADMIN->value,
     ]);
 });
 
@@ -39,12 +39,12 @@ test('seed with an admin user', function () {
     seed([PermissionSeeder::class, UserSeeder::class]);
 
     assertDatabaseHas('permissions', [
-        'key' => 'be an admin',
+        'key' => Can::BE_AN_ADMIN->value,
     ]);
 
     assertDatabaseHas('permission_user', [
         'user_id'       => User::first()?->id,
-        'permission_id' => Permission::where('key', '=', 'be an admin')->first()?->id,
+        'permission_id' => Permission::where('key', '=', Can::BE_AN_ADMIN->value)->first()?->id,
     ]);
 });
 
@@ -60,7 +60,7 @@ test('should block the access to an admin page if the user does not hava the per
 test('lets make sure that we are using cache to store user permissions', function () {
     $user = User::factory()->create();
 
-    $user->givePermissionTo('be an admin');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     $cacheKey = "user::{$user->id}::permissions";
 
@@ -71,11 +71,11 @@ test('lets make sure that we are using cache to store user permissions', functio
 test('lets make sure that we are using the cache the retrieve/check when the user has the given permission', function () {
     $user = User::factory()->create();
 
-    $user->givePermissionTo('be an admin');
+    $user->givePermissionTo(Can::BE_AN_ADMIN);
 
     // Verificar que eu nao teve nenhum hit no bd a partir desse ponto
     DB::listen(fn ($query) => throw new Exception('We got a hit'));
-    $user->hasPermissionTo('be an admin');
+    $user->hasPermissionTo(Can::BE_AN_ADMIN->value);
 
     expect(true)->toBeTrue();
 });


### PR DESCRIPTION
- **crm-5: user model has all the methods to control permission for the given user**
- **crm-5: creating a seed for permissions**
- **crm-5: creating a seed for admins**
- **crm-5: create a middleware to protect admin routes**
- **crm-5: installing LaraDump**
- **crm-5: using cache to store/retrive user permissions**
- **crm-5: refactoring permissions to his trait**
- **crm-5: refactoring to use ENUM**
- **crm-5: refactoring enum and trait files and move them to their own place**
- **crm-5: create a arch test to avoid commiting dd, dump, ray, ds**
- **crm-5: typo**
- **crm-5: refactoring route to use ENUM and adding admin menu item**
- **crm-5: authorize access to admin dashboard from route and component level**
